### PR TITLE
Fix for hardware supers.

### DIFF
--- a/DevCPU/src/devcpu/emulation/VirtualClock.java
+++ b/DevCPU/src/devcpu/emulation/VirtualClock.java
@@ -14,7 +14,7 @@ public class VirtualClock extends DCPUHardware
 
   public VirtualClock(String id, HardwareManager manager)
   {
-    super(315667458, 32776, 515079825);
+    super(0x12d0b402, 0x0001, 0x00000000);
     this.id = id;
     this.manager = manager;
   }

--- a/DevCPU/src/devcpu/emulation/VirtualKeyboard.java
+++ b/DevCPU/src/devcpu/emulation/VirtualKeyboard.java
@@ -27,7 +27,7 @@ public class VirtualKeyboard extends DCPUHardware
 
   public VirtualKeyboard(String id, HardwareManager manager, KeyMapping keyMapping)
   {
-    super(0x30cf7406, 0x1337, 0x1EB37E91);
+    super(0x30cf7406, 0x0001, 0x00000000);
     this.keyMapping = keyMapping;
     this.id = id;
     this.manager = manager;


### PR DESCRIPTION
I fixed the supers of the generic hardware to match the spec at dcpu.com.
I changed the manufacturers that are unspecified in the spec to 0,
as this seems more logical and is what most emulators implement
as far as I know. This means that more DASM code can work on DevCPU
without changes.
